### PR TITLE
Remove ./ from wireshark folder

### DIFF
--- a/chapter5/start-wiremock.sh
+++ b/chapter5/start-wiremock.sh
@@ -1,4 +1,4 @@
-docker run -it --rm -p 8080:8080 -p 8443:8443 --name wiremock --volume .\wiremock:/home/wiremock/mappings wiremock/wiremock:2.35.0  --verbose
+docker run -it --rm -p 8080:8080 -p 8443:8443 --name wiremock --volume wiremock:/home/wiremock/mappings wiremock/wiremock:2.35.0  --verbose
 # https://wiremock.org/docs/standalone/docker/
 # http://localhost:8080/__admin/mappings
 # http://localhost:8080/__admin/requests


### PR DESCRIPTION
When these characters are there there is the following error:

docker: Error response from daemon: create .wiremock: ".wiremock" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.